### PR TITLE
Add reusable workflow for CI and unit test pipeline

### DIFF
--- a/.github/workflows/env.yaml
+++ b/.github/workflows/env.yaml
@@ -1,0 +1,90 @@
+name: CI Environment - Reusable Workflow
+
+on:
+  workflow_call:
+     inputs:
+      job-name:
+        description: 'The name of the job that will be executed.  This name should be unique within the context of any given workflow'
+        required: true
+        type: string
+      
+      command-to-execute:
+        description: 'The command (or set of commands) that will be executed for this job'
+        required: true
+        type: string
+
+      run-location:
+        description: 'This is the runner that will be used for this job (ubuntu-latest, ubuntu-latest-large, self-hosted, etc)'
+        required: false
+        type: string
+        default: ubuntu-latest
+
+      timeout:
+        description: 'This is the timeout for this job (in minutes)'
+        required: false
+        type: number
+        default: 20
+
+jobs:
+  run:
+    timeout-minutes: ${{ inputs.timeout }}
+
+    runs-on: ${{ inputs.run-location }}
+
+    env:
+      CI: true
+
+    steps:
+      - name: Workflow execution environment
+        run: |
+          echo ${{ inputs.run-location }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: go.sum
+          cache: false
+
+      - name: Run
+        run: | 
+          errorCode=0
+          for i in {0..0}; do
+            # Since we 'set -e', any failure in here will case this 
+            # action to fail-fast, unless we catch it and retry
+            ${{ inputs.command-to-execute }}  
+          done
+
+          # if errorCode is not 0, and retry-on-failure is true, then retry
+          if [ $errorCode -ne 0 ] && ${{ inputs.retry-on-failure }}; then
+            errorCode=0
+            echo -e "\n###\n### RETRYING THIS ACTION\n###\n$"   
+            mkdir -p tests/flakyTests
+            mv tests/logs/ tests/flakyTests
+            mkdir -p tests/logs
+            for i in {0..0}; do
+              ${{ inputs.command-to-execute }}  # Try again in case of networking hiccup, fail otherwise
+            done 
+            if [ $errorCode -ne 0 ]; then
+              exit $errorCode
+            fi
+            mv tests/flakyTests tests/logs
+            echo "::warning title=Step passed after retrying::Failed on first attempt, but passed on retry. Any logs from flaky tests will be in the 'flakyTests' directory (see artifacts)"
+          fi
+
+          exit $errorCode
+
+      - name: Record logs
+        if: always()
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: Logs-${{ inputs.job-name }}
+          path: |
+            tests/logs
+          if-no-files-found: ignore
+          compression-level: 1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,54 @@
+name: Tests - Unit Tests
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
+  
+  pull_request:
+    
+  merge_group:
+
+jobs:
+
+  # --- Linting, Unit Tests, and Coverage ---
+
+  linter:
+    uses: ./.github/workflows/env.yaml
+    with:
+      job-name: linter
+      use-build-cache: true
+      command-to-execute: |
+        make lint
+    secrets: inherit
+
+  ut-services:
+    uses: ./.github/workflows/env.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [
+          userserver,
+          # gameengineserver,
+        ]
+    with:
+      job-name: ut-${{ matrix.module }}
+      use-build-cache: true
+      retry-on-failure: true
+      command-to-execute: |
+        make cov-${{ matrix.module }} || errorCode=$?
+    secrets: inherit
+
+  report-ut-coverage:
+    if: always()
+    needs: [ 
+      ut-services,
+    ]
+    uses: ./.github/workflows/env.yaml
+    with:
+      job-name: report-ut-coverage
+      pull-previous-logs: true
+      command-to-execute: |
+        make print-coverage
+    secrets: inherit

--- a/scripts/_makefiles/tests_unit.mk
+++ b/scripts/_makefiles/tests_unit.mk
@@ -42,13 +42,13 @@ template-cov:
 ###
 
 ut-userserver:
-	@make template-ut package=services/user
+	@make template-ut package=services/user packageName=userserver
 
 cov-userserver:
-	@make template-cov package=services/user
+	@make template-cov package=services/user packageName=userserver
 
 ut-gameengineserver:
-	@make template-ut package=services/game_engine
+	@make template-ut package=services/game_engine packageName=gameengineserver
 
 cov-gameengineserver:
-	@make template-cov package=services/game_engine
+	@make template-cov package=services/game_engine packageName=gameengineserver


### PR DESCRIPTION
Introduces a reusable GitHub Actions workflow for CI tasks with configurable inputs like job name, commands, runner location, and timeout. Adds specific workflows for linting, unit tests, and coverage reporting. Updates Makefile scripts to align with new structure by introducing `packageName` for clarity in test and coverage commands. Enhances modularity and reusability of CI processes.